### PR TITLE
Adjust glob call and SSINS version info

### DIFF
--- a/notebooks/rfi_inspect.ipynb
+++ b/notebooks/rfi_inspect.ipynb
@@ -26,7 +26,8 @@
     "from astropy import units\n",
     "from copy import deepcopy\n",
     "from pyuvdata import UVFlag\n",
-    "from SSINS import INS, version\n",
+    "from SSINS import INS\n",
+    "from SSINS import version as SSINS_ver\n",
     "import matplotlib.colors as colors\n",
     "from matplotlib import cm\n",
     "\n",
@@ -92,7 +93,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ssins_dirs_sorted = sorted(glob.glob(f\"{data_path}/*.SSINS\"))\n",
+    "ssins_dirs_sorted = sorted(glob.glob(f\"{data_path}/zen.{JD}*.SSINS\"))\n",
     "init_ssins_path = glob.glob(f\"{ssins_dirs_sorted[0]}/*flags.h5\")\n",
     "ssins_uvf = UVFlag(init_ssins_path)\n",
     "for path in ssins_dirs_sorted[1:]:\n",
@@ -618,8 +619,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "SSINS_version_info_list = [f'{key}: {version.version_info[key]}, ' for key in version.version_info]\n",
-    "print(f\"SSINS version info: {SSINS_version_info_list[:-1]}\")"
+    "print(f\"SSINS version info: {SSINS_ver.construct_version_info()}\")"
    ]
   },
   {
@@ -660,7 +660,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.6"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
Found two glaring errors. Other possible errors were hidden by failed cells. First, it was grabbing all SSINS files, instead of just ones for the relevant JD, and second, it was printing hera_qm's version info instead of SSINS'.