### PR TITLE
Remove git links from setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # hera_notebook_templates
-Repository for HERA analysis / real-time pipeline jupyter notebooks and related support code
+Repository for HERA analysis / real-time pipeline jupyter notebooks and related
+support code
 
 # Installation
-Install using `pip install --no-deps .` from within the head directory. If you plan to do development on this code base, install using `pip install --no-deps -e .` instead.
+Install using `pip install .` from within the head directory. If you plan to do
+development on this code base, install using `pip install -e .`  instead.

--- a/setup.py
+++ b/setup.py
@@ -49,9 +49,9 @@ setup_args = {
         'scipy',
         'astropy',
         'pyuvdata',
-        'uvtools @ git+git://github.com/HERA-Team/uvtools',
-        'hera_mc @ git+git://github.com/HERA-Team/hera_mc',
-        'hera_qm @ git+git://github.com/HERA-Team/hera_qm',
+        'uvtools',
+        'hera-mc',
+        'hera-qm',
         'bokeh',
     ],
     'extras_require': {


### PR DESCRIPTION
This PR changes `setup.py` so that git links are not specified. The packages in question are now on PyPI, so we can relax this requirement.

Closes #24 (in that it removes these links entirely).