### PR TITLE
fix: when gains are zero, remove them

### DIFF
--- a/notebooks/file_calibration.ipynb
+++ b/notebooks/file_calibration.ipynb
@@ -1087,6 +1087,23 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "de492cac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Any gains that have zeros in them must be \n",
+    "# removed (both from vis.sol and vis.gains)\n",
+    "remove = []\n",
+    "for ant, gain in sol.gains.items():\n",
+    "    if np.any(gain == 0):\n",
+    "        remove.append(ant)\n",
+    "for ant in remove:\n",
+    "    del sol.gains[ant]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "933cbdf4",
    "metadata": {},
    "outputs": [],
@@ -1394,7 +1411,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "hera",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1408,7 +1425,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6 | packaged by conda-forge | (main, Aug 22 2022, 20:36:39) [GCC 10.4.0]"
+   "version": "3.9.6"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
I was having a problem where some gains were completely zero after expanding the solutions to flagged antennas. I tried to fix this at the lower level in `hera_cal` but ended up causing other problems. This fix to the notebook does the job (but perhaps @jsdillon you know a better way to achieve this)