### PR TITLE
Add updated file_postprocessing notebook w/ DPSS filter caching

### DIFF
--- a/notebooks/file_postprocessing.ipynb
+++ b/notebooks/file_postprocessing.ipynb
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "fe4882c5",
    "metadata": {},
    "outputs": [],
@@ -41,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "612b6de5",
    "metadata": {},
    "outputs": [],
@@ -52,6 +52,8 @@
     "import hdf5plugin  # REQUIRED to have the compression plugins available\n",
     "import numpy as np\n",
     "import copy\n",
+    "import pickle\n",
+    "import glob\n",
     "from hera_cal import io, utils, redcal, apply_cal, datacontainer, vis_clean\n",
     "from hera_filters import dspec\n",
     "from hera_qm.metrics_io import read_a_priori_ant_flags\n",
@@ -72,10 +74,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "3265dc3a",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DIFF_FILE = '/users/jsdillon/lustre/H6C/abscal/2459853/zen.2459853.39413.diff.uvh5'\n",
+      "ABS_CAL_FILE = '/users/jsdillon/lustre/H6C/abscal/2459853/zen.2459853.39413.sum.omni.calfits'\n",
+      "SMOOTH_CAL_FILE = '/users/jsdillon/lustre/H6C/abscal/2459853/zen.2459853.39413.sum.smooth.calfits'\n",
+      "SUM_SMOOTH_CAL_RED_AVG_FILE = '/users/jsdillon/lustre/H6C/abscal/2459853/zen.2459853.39413.sum.smooth_calibrated.red_avg.uvh5'\n",
+      "DIFF_SMOOTH_CAL_RED_AVG_FILE = '/users/jsdillon/lustre/H6C/abscal/2459853/zen.2459853.39413.diff.smooth_calibrated.red_avg.uvh5'\n",
+      "SUM_ABSCAL_RED_AVG_FILE = '/users/jsdillon/lustre/H6C/abscal/2459853/zen.2459853.39413.sum.abs_calibrated.red_avg.uvh5'\n",
+      "DIFF_ABSCAL_RED_AVG_FILE = '/users/jsdillon/lustre/H6C/abscal/2459853/zen.2459853.39413.diff.abs_calibrated.red_avg.uvh5'\n",
+      "SUM_SMOOTH_CAL_RED_AVG_DLY_FILT_FILE = '/users/jsdillon/lustre/H6C/abscal/2459853/zen.2459853.39413.sum.smooth_calibrated.red_avg.dly_filt.uvh5'\n",
+      "DIFF_SMOOTH_CAL_RED_AVG_DLY_FILT_FILE = '/users/jsdillon/lustre/H6C/abscal/2459853/zen.2459853.39413.diff.smooth_calibrated.red_avg.dly_filt.uvh5'\n",
+      "AVG_ABS_ALL_FILE = '/users/jsdillon/lustre/H6C/abscal/2459853/zen.2459853.39413.sum.smooth_calibrated.avg_abs_all.uvh5'\n",
+      "AVG_ABS_AUTO_FILE = '/users/jsdillon/lustre/H6C/abscal/2459853/zen.2459853.39413.sum.smooth_calibrated.avg_abs_auto.uvh5'\n",
+      "AVG_ABS_CROSS_FILE = '/users/jsdillon/lustre/H6C/abscal/2459853/zen.2459853.39413.sum.smooth_calibrated.avg_abs_cross.uvh5'\n",
+      "aposteriori_yaml_file = /users/jsdillon/lustre/H6C/abscal/2459853/2459853_aposteriori_flags.yaml\n",
+      "filter_cache = /users/jsdillon/lustre/H6C/abscal/2459853/filter_cache\n"
+     ]
+    }
+   ],
    "source": [
     "# figure out whether to save results\n",
     "SAVE_RESULTS = os.environ.get(\"SAVE_RESULTS\", \"TRUE\").upper() == \"TRUE\"\n",
@@ -83,7 +106,7 @@
     "\n",
     "# get input data file names\n",
     "SUM_FILE = os.environ.get(\"SUM_FILE\", None)\n",
-    "# SUM_FILE = '/users/jsdillon/lustre/H6C/abscal/2459853/zen.2459853.39413.sum.uvh5'\n",
+    "SUM_FILE = '/users/jsdillon/lustre/H6C/abscal/2459853/zen.2459853.39413.sum.uvh5'\n",
     "SUM_SUFFIX = os.environ.get(\"SUM_SUFFIX\", 'sum.uvh5')\n",
     "DIFF_SUFFIX = os.environ.get(\"DIFF_SUFFIX\", 'diff.uvh5')\n",
     "\n",
@@ -92,6 +115,10 @@
     "SMOOTH_CAL_SUFFIX = os.environ.get(\"CAL_SUFFIX\", 'sum.smooth.calfits')\n",
     "APOSTERIORI_YAML_SUFFIX = os.environ.get(\"APOSTERIORI_YAML_SUFFIX\", '_aposteriori_flags.yaml')\n",
     "aposteriori_yaml_file = os.path.join(os.path.dirname(SUM_FILE), SUM_FILE.split('.')[-4] + APOSTERIORI_YAML_SUFFIX)\n",
+    "\n",
+    "# Get filter cache name\n",
+    "FILTER_CACHE = os.environ.get(\"FILTER_CACHE\", \"filter_cache\")\n",
+    "filter_cache_dir = os.path.join(os.path.dirname(SUM_FILE), FILTER_CACHE)\n",
     "\n",
     "# output abs-calibrated, redundantly-averaged files\n",
     "SUM_ABSCAL_RED_AVG_SUFFIX = os.environ.get(\"SUM_ABSCAL_RED_AVG_SUFFIX\", 'sum.abs_calibrated.red_avg.uvh5')\n",
@@ -116,15 +143,28 @@
     "    file_var = suffix.replace('SUFFIX', 'FILE')\n",
     "    exec(f'{file_var} = SUM_FILE.replace(SUM_SUFFIX, {suffix})')\n",
     "    print(f\"{file_var} = '{eval(file_var)}'\")\n",
-    "print(f'aposteriori_yaml_file = {aposteriori_yaml_file}')"
+    "print(f'aposteriori_yaml_file = {aposteriori_yaml_file}')\n",
+    "print(f'filter_cache = {filter_cache_dir}')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "e7489bb3",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DLY_FILT_HORIZON = 1.0\n",
+      "DLY_FILT_STANDOFF = 0.0\n",
+      "DLY_FILT_MIN_DLY = 150.0\n",
+      "DLY_FILT_EIGENVAL_CUTOFF = 1e-12\n",
+      "DLY_FILT_FM_CUT_FREQ = 100000000.0\n"
+     ]
+    }
+   ],
    "source": [
     "# parse delay filtering settings\n",
     "DLY_FILT_HORIZON = float(os.environ.get(\"DLY_FILT_HORIZON\", 1.0))\n",
@@ -134,6 +174,17 @@
     "DLY_FILT_FM_CUT_FREQ = float(os.environ.get(\"DLY_FILT_FM_CUT_FREQ\", 100e6)) # in Hz\n",
     "for setting in ['DLY_FILT_HORIZON', 'DLY_FILT_STANDOFF', 'DLY_FILT_MIN_DLY', 'DLY_FILT_EIGENVAL_CUTOFF', 'DLY_FILT_FM_CUT_FREQ']:\n",
     "        print(f'{setting} = {eval(setting)}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2fa4e3b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Find all cached matrices within the filter cache\n",
+    "cache_files = glob.glob(os.path.join(filter_cache_dir, \"*.filter_cache\"))"
    ]
   },
   {
@@ -387,6 +438,32 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 14,
+   "id": "4e7d4f5e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def read_filter_cache_scratch(cache_files):\n",
+    "    \"\"\"\n",
+    "    Load files from a cache specified by cache_dir.\n",
+    "    \"\"\"\n",
+    "    # Load up the cache file with the most keys (precomputed filter matrices).\n",
+    "    cache = {}\n",
+    "    # loop through cache files, load them.\n",
+    "    # If there are new keys, add them to internal cache.\n",
+    "    # If not, delete the reference matrices from memory.\n",
+    "    for cache_file in cache_files:\n",
+    "        cfile = open(cache_file, 'rb')\n",
+    "        cache_t = pickle.load(cfile)\n",
+    "        for key in cache_t:\n",
+    "            if key not in cache:\n",
+    "                cache[key] = cache_t[key]\n",
+    "                \n",
+    "    return cache"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "id": "3dad2291",
    "metadata": {},
@@ -412,8 +489,16 @@
     "if ALL_FLAGGED and np.all([np.all(~cal_flags[ant]) for ant in cal_flags]):\n",
     "    print('All integrations flagged after the file_calibration notebook... skipping delay filtering.')\n",
     "else:    \n",
+    "    # Load files in cache\n",
+    "    try:\n",
+    "        cache = read_filter_cache_scratch(cache_files)\n",
+    "        cache_keys = [key[0] for key in cache]\n",
+    "    except:\n",
+    "        cache = {}\n",
+    "        cache_keys = []\n",
+    "    \n",
+    "    new_cache_keys = []\n",
     "    saved_mdls = {}\n",
-    "    cache = {}\n",
     "    for bl in sorted(red_avg_flags.keys(), key=lambda bl: np.sum(red_avg_flags[bl]), reverse=True):\n",
     "        # inverse variance weight using autocorrealtions (which are proprotional to std of noise)\n",
     "        auto_bl = [abl for abl in auto_bls if abl[2] == bl[2]][0]\n",
@@ -437,6 +522,14 @@
     "                                                               filter_half_widths=filter_half_widths, mode='dpss_leastsq', \n",
     "                                                               eigenval_cutoff=[DLY_FILT_EIGENVAL_CUTOFF], suppression_factors=[DLY_FILT_EIGENVAL_CUTOFF], \n",
     "                                                               max_contiguous_edge_flags=len(hd.freqs), cache=cache)\n",
+    "                \n",
+    "                # Track new DPSS-filters entering the cache\n",
+    "                fourier_filter_key = dspec._fourier_filter_hash(\n",
+    "                    filter_centers=filter_centers, filter_half_widths=filter_half_widths, filter_factors=[0.], x=hd.freqs[band], w=None,\n",
+    "                    crit_name='eigenval_cutoff', label='dpss_operator', crit_val=tuple([DLY_FILT_EIGENVAL_CUTOFF])\n",
+    "                )\n",
+    "                if fourier_filter_key not in cache_keys:\n",
+    "                    new_cache_keys.append(fourier_filter_key)\n",
     "\n",
     "            # save a few models for plotting\n",
     "            if i == 0 and (np.abs(bl_vec[1]) < 1) and int(np.round(bl_vec[0] / 14.6)) in [0, 1, 3, 5, 7]:\n",
@@ -448,16 +541,6 @@
     "            else:\n",
     "                # for all other baselines, filter foregrounds\n",
     "                dc[bl] = np.where(red_avg_flags[bl], 0, dc[bl] - d_mdl)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "408241b8",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# TODO: add cache io for faster parallel computation"
    ]
   },
   {
@@ -645,6 +728,39 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0f4d2551",
+   "metadata": {},
+   "source": [
+    "## Save filter cache"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "1011f4be",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if SAVE_RESULTS:\n",
+    "    # Create cache directory if it doesn't already exist\n",
+    "    if not os.path.exists(filter_cache_dir):\n",
+    "        os.mkdir(filter_cache_dir)\n",
+    "        \n",
+    "    # For each new cache key save a new cache file in the cache directory\n",
+    "    for key in new_cache_keys:\n",
+    "        cache_file_basename = key[0] + '.filter_cache'\n",
+    "        if not os.path.exists(os.path.join(filter_cache_dir, cache_file_basename)):\n",
+    "            try:\n",
+    "                cfile = open(os.path.join(filter_cache_dir, cache_file_basename), 'wb')\n",
+    "                pickle.dump({key: cache[key]}, cfile)\n",
+    "                cfile.close()\n",
+    "            except (OSError, IOError):\n",
+    "                # File could not be written to, move on\n",
+    "                pass"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "530f8747",
    "metadata": {},
    "source": [
@@ -690,7 +806,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.8.8"
   },
   "toc": {
    "base_numbering": 1,

--- a/notebooks/file_postprocessing.ipynb
+++ b/notebooks/file_postprocessing.ipynb
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "fe4882c5",
    "metadata": {},
    "outputs": [],
@@ -41,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "612b6de5",
    "metadata": {},
    "outputs": [],
@@ -74,31 +74,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "3265dc3a",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DIFF_FILE = '/users/jsdillon/lustre/H6C/abscal/2459853/zen.2459853.39413.diff.uvh5'\n",
-      "ABS_CAL_FILE = '/users/jsdillon/lustre/H6C/abscal/2459853/zen.2459853.39413.sum.omni.calfits'\n",
-      "SMOOTH_CAL_FILE = '/users/jsdillon/lustre/H6C/abscal/2459853/zen.2459853.39413.sum.smooth.calfits'\n",
-      "SUM_SMOOTH_CAL_RED_AVG_FILE = '/users/jsdillon/lustre/H6C/abscal/2459853/zen.2459853.39413.sum.smooth_calibrated.red_avg.uvh5'\n",
-      "DIFF_SMOOTH_CAL_RED_AVG_FILE = '/users/jsdillon/lustre/H6C/abscal/2459853/zen.2459853.39413.diff.smooth_calibrated.red_avg.uvh5'\n",
-      "SUM_ABSCAL_RED_AVG_FILE = '/users/jsdillon/lustre/H6C/abscal/2459853/zen.2459853.39413.sum.abs_calibrated.red_avg.uvh5'\n",
-      "DIFF_ABSCAL_RED_AVG_FILE = '/users/jsdillon/lustre/H6C/abscal/2459853/zen.2459853.39413.diff.abs_calibrated.red_avg.uvh5'\n",
-      "SUM_SMOOTH_CAL_RED_AVG_DLY_FILT_FILE = '/users/jsdillon/lustre/H6C/abscal/2459853/zen.2459853.39413.sum.smooth_calibrated.red_avg.dly_filt.uvh5'\n",
-      "DIFF_SMOOTH_CAL_RED_AVG_DLY_FILT_FILE = '/users/jsdillon/lustre/H6C/abscal/2459853/zen.2459853.39413.diff.smooth_calibrated.red_avg.dly_filt.uvh5'\n",
-      "AVG_ABS_ALL_FILE = '/users/jsdillon/lustre/H6C/abscal/2459853/zen.2459853.39413.sum.smooth_calibrated.avg_abs_all.uvh5'\n",
-      "AVG_ABS_AUTO_FILE = '/users/jsdillon/lustre/H6C/abscal/2459853/zen.2459853.39413.sum.smooth_calibrated.avg_abs_auto.uvh5'\n",
-      "AVG_ABS_CROSS_FILE = '/users/jsdillon/lustre/H6C/abscal/2459853/zen.2459853.39413.sum.smooth_calibrated.avg_abs_cross.uvh5'\n",
-      "aposteriori_yaml_file = /users/jsdillon/lustre/H6C/abscal/2459853/2459853_aposteriori_flags.yaml\n",
-      "filter_cache = /users/jsdillon/lustre/H6C/abscal/2459853/filter_cache\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# figure out whether to save results\n",
     "SAVE_RESULTS = os.environ.get(\"SAVE_RESULTS\", \"TRUE\").upper() == \"TRUE\"\n",
@@ -149,22 +128,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "e7489bb3",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DLY_FILT_HORIZON = 1.0\n",
-      "DLY_FILT_STANDOFF = 0.0\n",
-      "DLY_FILT_MIN_DLY = 150.0\n",
-      "DLY_FILT_EIGENVAL_CUTOFF = 1e-12\n",
-      "DLY_FILT_FM_CUT_FREQ = 100000000.0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# parse delay filtering settings\n",
     "DLY_FILT_HORIZON = float(os.environ.get(\"DLY_FILT_HORIZON\", 1.0))\n",
@@ -438,7 +405,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "4e7d4f5e",
    "metadata": {},
    "outputs": [],
@@ -456,8 +423,7 @@
     "        cfile = open(cache_file, 'rb')\n",
     "        cache_t = pickle.load(cfile)\n",
     "        for key in cache_t:\n",
-    "            if key not in cache:\n",
-    "                cache[key] = cache_t[key]\n",
+    "            cache[key] = cache_t[key]\n",
     "                \n",
     "    return cache"
    ]
@@ -492,7 +458,7 @@
     "    # Load files in cache\n",
     "    try:\n",
     "        cache = read_filter_cache_scratch(cache_files)\n",
-    "        cache_keys = [key[0] for key in cache]\n",
+    "        cache_keys = list(cache.keys())\n",
     "    except:\n",
     "        cache = {}\n",
     "        cache_keys = []\n",
@@ -503,7 +469,8 @@
     "        # inverse variance weight using autocorrealtions (which are proprotional to std of noise)\n",
     "        auto_bl = [abl for abl in auto_bls if abl[2] == bl[2]][0]\n",
     "        wgts = np.where(red_avg_flags[bl], 0, red_avg_smooth_cal_sum_data[auto_bl]**-2)\n",
-    "\n",
+    "        wgts /= np.nanmean(np.where(red_avg_flags[bl], np.nan, wgts))  # avoid dynamic range issues\n",
+    "        \n",
     "        # calculate filter properties\n",
     "        bl_vec = (hd.antpos[bl[1]] - hd.antpos[bl[0]])\n",
     "        bl_len = np.linalg.norm(bl_vec[:2]) / constants.c\n",
@@ -519,7 +486,7 @@
     "            d_mdl = np.zeros_like(dc[bl])\n",
     "            for band in [low_band, high_band]:\n",
     "                d_mdl[:, band], _, info = dspec.fourier_filter(hd.freqs[band], dc[bl][:, band], wgts=wgts[:, band], filter_centers=filter_centers, \n",
-    "                                                               filter_half_widths=filter_half_widths, mode='dpss_leastsq', \n",
+    "                                                               filter_half_widths=filter_half_widths, mode='dpss_solve', \n",
     "                                                               eigenval_cutoff=[DLY_FILT_EIGENVAL_CUTOFF], suppression_factors=[DLY_FILT_EIGENVAL_CUTOFF], \n",
     "                                                               max_contiguous_edge_flags=len(hd.freqs), cache=cache)\n",
     "                \n",
@@ -736,7 +703,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "id": "1011f4be",
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION
New updates to `file_postprocessing` that allow for read/writing of cached DPSS filters to speed-up delay-filtering