### PR TITLE
Add signal loss calculation based on Pascua+2024

### DIFF
--- a/notebooks/single_baseline_postprocessing_and_pspec.ipynb
+++ b/notebooks/single_baseline_postprocessing_and_pspec.ipynb
@@ -551,7 +551,7 @@
     "xtalk_overlaps = {}\n",
     "for band, bs in zip(bands, band_slices):\n",
     "    taper = dspec.gen_window(TAPER, len(data.freqs[bs]))\n",
-    "    band_avg_fr_spectrum = np.average(interp_fr_spectrum[:, bs], weights=taper, axis=1)\n",
+    "    band_avg_fr_spectrum = np.average(interp_fr_spectrum[:, bs], weights=taper**2, axis=1)\n",
     "    band_avg_fr_spectrum /= np.sum(band_avg_fr_spectrum)\n",
     "    fr_profiles[band] = band_avg_fr_spectrum\n",
     "    cumsum_interpolator = interpolate.interp1d(np.cumsum(band_avg_fr_spectrum), frates)\n",
@@ -567,44 +567,6 @@
     "    xtalk_overlaps[band] = overlap_frs(fr_ranges[band], [-XTALK_FR, XTALK_FR])\n",
     "    if xtalk_overlaps[band] is not None:\n",
     "        frf_losses[band] += frate_interpolator(xtalk_overlaps[band][1]) - frate_interpolator(xtalk_overlaps[band][0])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "30",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def show_FR_table():\n",
-    "    table = pd.DataFrame({'Band': np.arange(len(bands)) + 1,\n",
-    "                          'Frequency Range (MHz)': [f'{f0:.1f} — {f1:.1f}' for f0, f1 in zip(min_freqs, max_freqs)],\n",
-    "                          f'Main Beam {FR_QUANTILE_LOW:.0%} — {FR_QUANTILE_HIGH:.0%}<br>Kept Fringe Rates (mHz)': [f'{frs[0]:.3f} to {frs[1]:.3f}' for frs in fr_ranges.values()],\n",
-    "                          f'Approximate Signal Loss with<br>{-XTALK_FR} to {XTALK_FR} mHz X-Talk Filter': [f'{loss:.0%}' for loss in frf_losses.values()],\n",
-    "                         })\n",
-    "    return table.style.hide().to_html()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1e29882d",
-   "metadata": {},
-   "source": [
-    "# *Table 2: Fringe-Rate and Crosstalk Filtering Ranges and Losses*\n",
-    "\n",
-    "Note that these losses are approximate and assume perfectly sharp filters. Extra extent in fringe-rate space (which is controlled by `FR_EIGENVAL_CUTOFF`) will reduce loss when performing the main beam fringe-rate filter (because it is a top hat). It will also will increase the loss due to the crosstalk filtering (because it is a notch) if and only if there's an overlap between the two filters.\n",
-    "\n",
-    "TODO: As a future feature, we'd like to implement Bobby's full transfer-matrix formalism for figuring out the actual loss given the set of DPSS filters used here."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "05cff2a8",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "HTML(show_FR_table())"
    ]
   },
   {
@@ -1192,6 +1154,133 @@
     "deint_flags = deinterleave_datacontainer(filt_flags, ninterleave=NINTERLEAVE, tslice=tslice)\n",
     "deint_nsamples = deinterleave_datacontainer(filt_nsamples, ninterleave=NINTERLEAVE, tslice=tslice)\n",
     "deint_wgts = deinterleave_datacontainer(time_filt_wgts, ninterleave=NINTERLEAVE, tslice=tslice)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2bc7426f-4aff-40ef-96d5-460a874b9c4d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Helper fft functions for signal loss calculation.\n",
+    "def FFT(data, axis):\n",
+    "    \"\"\"Thin wrapper around fft stuff.\"\"\"\n",
+    "    return np.fft.fftshift(np.fft.fft(np.fft.ifftshift(data, axes=axis), axis=axis), axes=axis)\n",
+    "\n",
+    "def IFFT(data, axis):\n",
+    "    \"\"\"Thin wrapper around ifft stuff.\"\"\"\n",
+    "    return np.fft.ifftshift(np.fft.ifft(np.fft.fftshift(data, axes=axis), axis=axis), axes=axis)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8392c501-7817-40fd-98f3-b0596fa34ab3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def construct_filter(times, fc, fhw, eigval_cutoff=FR_EIGENVAL_CUTOFF, wgts=None):\n",
+    "    \"\"\"Compute the time-domain DPSS filter matrix.\"\"\"\n",
+    "    if wgts is None:\n",
+    "        wgts = np.ones(times.size)\n",
+    "        \n",
+    "    # Compute the phasor for shifting the DPSS modes to the filter center.\n",
+    "    frf_phasor = np.exp(-2j * np.pi * fc * (times-times.mean()))\n",
+    "    \n",
+    "    # Compute the B*W parameter for defining the DPSS modes.\n",
+    "    half_bandwidth = (times[-1] - times[0]) * fhw\n",
+    "    \n",
+    "    # Approximation for the extra number of modes to compute beyond 2*B*W\n",
+    "    n_extra_modes = int(\n",
+    "        4 * np.log(4*times.size) * np.log(4/eigval_cutoff) / np.pi**2\n",
+    "    )\n",
+    "    \n",
+    "    # Generate the DPSS modes used for filtering.\n",
+    "    n_modes = int(2 * half_bandwidth) + n_extra_modes\n",
+    "    modes, eigvals = dpss(\n",
+    "        times.size, half_bandwidth, Kmax=n_modes, return_ratios=True\n",
+    "    )\n",
+    "    \n",
+    "    # Apply the eigenvalue cutoff and rephase to the filter center.\n",
+    "    cut = np.argwhere(eigvals >= eigval_cutoff).flatten()[-1]\n",
+    "    modes = modes[:cut].T * frf_phasor[:,None]  # Shape (n_times, n_dpss)\n",
+    "    \n",
+    "    # Apply the weights, then compute the filter matrix.\n",
+    "    modes = wgts[:,None] * modes\n",
+    "    return modes @ np.linalg.inv(modes.T.conj() @ modes) @ modes.T.conj()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dd52dfdd-933f-452c-aac7-d24ae353ec25",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO: incorporate coherent average and time-interleaving to signal loss calculation.\n",
+    "\n",
+    "# Update frf signal loss calculation.\n",
+    "frf_losses = {} \n",
+    "for band, band_slice in zip(bands, band_slices):\n",
+    "    # The weights change as a function of frequency (due to the inverse noise weighting),\n",
+    "    # so this isn't entirely accurate; will need to update in the future.\n",
+    "    # Also need to more carefully consider how to combine the weights across polarization,\n",
+    "    # and which precise set of weights to use when filtering the data.\n",
+    "    wgts = np.mean([time_filt_wgts[bl][tslice,band_slice] for bl in cross_bls if bl[2][0] == bl[2][1]], axis=(0,2))\n",
+    "    \n",
+    "    # Compute the filter center and filter half-width.\n",
+    "    fmin, fmax = fr_ranges[band]\n",
+    "    fc = 0.5 * (fmin+fmax)  # mHz\n",
+    "    fhw = 0.5 * np.abs(fmax-fmin)  # mHz\n",
+    "    \n",
+    "    # Generate the main-lobe and crosstalk time-time filter matrices.\n",
+    "    main_lobe_filt = construct_filter(times_ks, fc, fhw, eigval_cutoff=FR_EIGENVAL_CUTOFF, wgts=wgts)\n",
+    "    xt_filt = np.eye(times_ks.size) - construct_filter(times_ks, 0, XTALK_FR, eigval_cutoff=FR_EIGENVAL_CUTOFF, wgts=wgts)\n",
+    "    \n",
+    "    # Fourier transform to obtain the fringe-rate filter matrices.\n",
+    "    filter_xfer_matrix = FFT(IFFT(main_lobe_filt @ xt_filt, axis=0), axis=1)\n",
+    "    \n",
+    "    # Now compute the signal loss.\n",
+    "    filtered_power = np.sum(fr_profiles[band][None,:] * np.abs(filter_xfer_matrix)**2)\n",
+    "    unfiltered_power = np.sum(fr_profiles[band])\n",
+    "    frf_losses[band] = 1 - filtered_power / unfiltered_power"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "30",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def show_FR_table():\n",
+    "    table = pd.DataFrame({'Band': np.arange(len(bands)) + 1,\n",
+    "                          'Frequency Range (MHz)': [f'{f0:.1f} — {f1:.1f}' for f0, f1 in zip(min_freqs, max_freqs)],\n",
+    "                          f'Main Beam {FR_QUANTILE_LOW:.0%} — {FR_QUANTILE_HIGH:.0%}<br>Kept Fringe Rates (mHz)': [f'{frs[0]:.3f} to {frs[1]:.3f}' for frs in fr_ranges.values()],\n",
+    "                          f'Approximate Signal Loss with<br>{-XTALK_FR} to {XTALK_FR} mHz X-Talk Filter': [f'{loss:.1%}' for loss in frf_losses.values()],\n",
+    "                         })\n",
+    "    return table.style.hide().to_html()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "682c710d-e9e3-49c7-8389-e05f70d54f20",
+   "metadata": {},
+   "source": [
+    "# *Table 2: Fringe-Rate and Crosstalk Filtering Ranges and Losses*\n",
+    "\n",
+    "Note that these losses are approximate and assume perfectly sharp filters. Extra extent in fringe-rate space (which is controlled by `FR_EIGENVAL_CUTOFF`) will reduce loss when performing the main beam fringe-rate filter (because it is a top hat). It will also will increase the loss due to the crosstalk filtering (because it is a notch) if and only if there's an overlap between the two filters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "05cff2a8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "HTML(show_FR_table())"
    ]
   },
   {
@@ -2035,7 +2124,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.11.10"
   },
   "toc": {
    "base_numbering": 1,

--- a/notebooks/single_baseline_postprocessing_and_pspec.ipynb
+++ b/notebooks/single_baseline_postprocessing_and_pspec.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Single Baseline Filtering and Power Spectrum Estimation\n",
     "\n",
-    "**by Josh Dillon**, last updated August 21, 2024\n",
+    "**by Josh Dillon and Bobby Pascua**, last updated August 21, 2024\n",
     "\n",
     "This notebook is designed to take a single redundantly-averaged unique baseline (typically after LST-binning) and push it through all the way to the power spectrum. It operates on single files that contain a single baseline for all LSTs and both `'ee'` and `'nn'` polarizations. It then can:\n",
     "* Throw out highly flagged times and/or channels\n",
@@ -476,97 +476,6 @@
     "    for bl in data:\n",
     "        if bl[0] == bl[1]:\n",
     "            data[bl] = 10000 * np.ones_like(data[bl])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ffa2c297",
-   "metadata": {},
-   "source": [
-    "## Figure out per-band fringe-rate filter ranges"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0243a535",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# TODO: graduate this code into hera_cal\n",
-    "\n",
-    "# load relevant FR spectrum vs. frequency and associated metadata\n",
-    "with h5py.File(FR_SPECTRA_FILE, \"r\") as h5f:\n",
-    "    metadata = h5f[\"metadata\"]\n",
-    "    bl_to_index_map = {tuple(ap): int(index) for index, antpairs in metadata[\"baseline_groups\"].items() for ap in antpairs}\n",
-    "    spectrum_freqs = metadata[\"frequencies_MHz\"][()] * 1e6\n",
-    "    m_modes = metadata[\"erh_mode_integer_index\"][()]\n",
-    "    if ANTPAIR in bl_to_index_map:\n",
-    "        mmode_spectrum = h5f[\"erh_mode_power_spectrum\"][:, :, bl_to_index_map[ANTPAIR]]\n",
-    "    else:\n",
-    "        # If ANTPAIR is not in the FR_SPECTRA_FILE, but the reverse is, also reverse the spectrum\n",
-    "        mmode_spectrum = h5f[\"erh_mode_power_spectrum\"][:, :, bl_to_index_map[ANTPAIR[::-1]]]\n",
-    "        m_modes *= -1"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ee58a2ac",
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "# TODO: graduate this code into hera_cal\n",
-    "\n",
-    "# convert to fringe rate, accouting for the fact that we have less than 24 hours of LST\n",
-    "def m2f(m_modes):\n",
-    "    # Convert m-modes to fringe-rates in mHz.\n",
-    "    return m_modes / units.sday.to(units.ks)\n",
-    "times_ks = (data.times[tslice] - data.times[0] + np.median(np.diff(data.times))) * units.day.to(units.ks)\n",
-    "m2f_phasors = np.exp(2j * np.pi * m2f(m_modes)[None, :] * times_ks[:, None])\n",
-    "m2f_mixer = np.fft.fftshift(np.fft.fft(np.fft.ifftshift(m2f_phasors, axes=0), axis=0), axes=0)\n",
-    "# f is fringe rate, m is m-mode, n is nu (i.e. freqeuency)\n",
-    "fr_spectrum = np.abs(np.einsum('fm,mn,mf->fn', m2f_mixer, mmode_spectrum, m2f_mixer.T.conj()))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5d1e29d9",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# TODO: graduate this code into hera_cal\n",
-    "\n",
-    "# interpolate to all frequencies in data\n",
-    "interp_fr_spectrum = interpolate.interp1d(spectrum_freqs, fr_spectrum, kind='cubic', fill_value='extrapolate')(data.freqs)    \n",
-    "frates = np.fft.fftshift(np.fft.fftfreq(len(times_ks), d=np.median(np.diff(times_ks))))\n",
-    "\n",
-    "# perform window-weighted average over each band, then get lower and upper quantiles\n",
-    "fr_ranges = {}\n",
-    "fr_profiles = {}\n",
-    "frf_losses = {}\n",
-    "xtalk_overlaps = {}\n",
-    "for band, bs in zip(bands, band_slices):\n",
-    "    taper = dspec.gen_window(TAPER, len(data.freqs[bs]))\n",
-    "    band_avg_fr_spectrum = np.average(interp_fr_spectrum[:, bs], weights=taper**2, axis=1)\n",
-    "    band_avg_fr_spectrum /= np.sum(band_avg_fr_spectrum)\n",
-    "    fr_profiles[band] = band_avg_fr_spectrum\n",
-    "    cumsum_interpolator = interpolate.interp1d(np.cumsum(band_avg_fr_spectrum), frates)\n",
-    "    fr_ranges[band] = cumsum_interpolator(FR_QUANTILE_LOW), cumsum_interpolator(FR_QUANTILE_HIGH)\n",
-    "    \n",
-    "    # account for overlap between FR=0 notch and main beam FRF\n",
-    "    def overlap_frs(frs1, frs2):\n",
-    "        start = np.maximum(frs1[0], frs2[0])\n",
-    "        end = np.minimum(frs1[1], frs2[1])\n",
-    "        return (start, end) if start < end else None\n",
-    "    frate_interpolator = interpolate.interp1d(frates, np.cumsum(band_avg_fr_spectrum))\n",
-    "    frf_losses[band] = 1 - frate_interpolator(fr_ranges[band][1]) + frate_interpolator(fr_ranges[band][0])\n",
-    "    xtalk_overlaps[band] = overlap_frs(fr_ranges[band], [-XTALK_FR, XTALK_FR])\n",
-    "    if xtalk_overlaps[band] is not None:\n",
-    "        frf_losses[band] += frate_interpolator(xtalk_overlaps[band][1]) - frate_interpolator(xtalk_overlaps[band][0])"
    ]
   },
   {
@@ -1157,6 +1066,97 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "6e54ba7a-7ae2-4ae1-b94c-0c5ef268e4df",
+   "metadata": {},
+   "source": [
+    "## Figure out per-band fringe-rate filter ranges"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0243a535",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO: graduate this code into hera_cal\n",
+    "\n",
+    "# load relevant FR spectrum vs. frequency and associated metadata\n",
+    "with h5py.File(FR_SPECTRA_FILE, \"r\") as h5f:\n",
+    "    metadata = h5f[\"metadata\"]\n",
+    "    bl_to_index_map = {tuple(ap): int(index) for index, antpairs in metadata[\"baseline_groups\"].items() for ap in antpairs}\n",
+    "    spectrum_freqs = metadata[\"frequencies_MHz\"][()] * 1e6\n",
+    "    m_modes = metadata[\"erh_mode_integer_index\"][()]\n",
+    "    if ANTPAIR in bl_to_index_map:\n",
+    "        mmode_spectrum = h5f[\"erh_mode_power_spectrum\"][:, :, bl_to_index_map[ANTPAIR]]\n",
+    "    else:\n",
+    "        # If ANTPAIR is not in the FR_SPECTRA_FILE, but the reverse is, also reverse the spectrum\n",
+    "        mmode_spectrum = h5f[\"erh_mode_power_spectrum\"][:, :, bl_to_index_map[ANTPAIR[::-1]]]\n",
+    "        m_modes *= -1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ee58a2ac",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# TODO: graduate this code into hera_cal\n",
+    "\n",
+    "# convert to fringe rate, accouting for the fact that we have less than 24 hours of LST\n",
+    "def m2f(m_modes):\n",
+    "    # Convert m-modes to fringe-rates in mHz.\n",
+    "    return m_modes / units.sday.to(units.ks)\n",
+    "times_ks = (data.times[tslice] - data.times[0] + np.median(np.diff(data.times))) * units.day.to(units.ks)\n",
+    "m2f_phasors = np.exp(2j * np.pi * m2f(m_modes)[None, :] * times_ks[:, None])\n",
+    "m2f_mixer = np.fft.fftshift(np.fft.fft(np.fft.ifftshift(m2f_phasors, axes=0), axis=0), axes=0)\n",
+    "# f is fringe rate, m is m-mode, n is nu (i.e. freqeuency)\n",
+    "fr_spectrum = np.abs(np.einsum('fm,mn,mf->fn', m2f_mixer, mmode_spectrum, m2f_mixer.T.conj()))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5d1e29d9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO: graduate this code into hera_cal\n",
+    "\n",
+    "# interpolate to all frequencies in data\n",
+    "interp_fr_spectrum = interpolate.interp1d(spectrum_freqs, fr_spectrum, kind='cubic', fill_value='extrapolate')(data.freqs)    \n",
+    "frates = np.fft.fftshift(np.fft.fftfreq(len(times_ks), d=np.median(np.diff(times_ks))))\n",
+    "\n",
+    "# perform window-weighted average over each band, then get lower and upper quantiles\n",
+    "fr_ranges = {}\n",
+    "fr_profiles = {}\n",
+    "frf_losses = {}\n",
+    "xtalk_overlaps = {}\n",
+    "for band, bs in zip(bands, band_slices):\n",
+    "    taper = dspec.gen_window(TAPER, len(data.freqs[bs]))\n",
+    "    band_avg_fr_spectrum = np.average(interp_fr_spectrum[:, bs], weights=taper**2, axis=1)\n",
+    "    band_avg_fr_spectrum /= np.sum(band_avg_fr_spectrum)\n",
+    "    fr_profiles[band] = band_avg_fr_spectrum\n",
+    "    cumsum_interpolator = interpolate.interp1d(np.cumsum(band_avg_fr_spectrum), frates)\n",
+    "    fr_ranges[band] = cumsum_interpolator(FR_QUANTILE_LOW), cumsum_interpolator(FR_QUANTILE_HIGH)\n",
+    "    \n",
+    "    # account for overlap between FR=0 notch and main beam FRF\n",
+    "    def overlap_frs(frs1, frs2):\n",
+    "        start = np.maximum(frs1[0], frs2[0])\n",
+    "        end = np.minimum(frs1[1], frs2[1])\n",
+    "        return (start, end) if start < end else None\n",
+    "    frate_interpolator = interpolate.interp1d(frates, np.cumsum(band_avg_fr_spectrum))\n",
+    "    frf_losses[band] = 1 - frate_interpolator(fr_ranges[band][1]) + frate_interpolator(fr_ranges[band][0])\n",
+    "    xtalk_overlaps[band] = overlap_frs(fr_ranges[band], [-XTALK_FR, XTALK_FR])\n",
+    "    if xtalk_overlaps[band] is not None:\n",
+    "        frf_losses[band] += frate_interpolator(xtalk_overlaps[band][1]) - frate_interpolator(xtalk_overlaps[band][0])"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "2bc7426f-4aff-40ef-96d5-460a874b9c4d",
@@ -1180,8 +1180,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# TODO: graduate this code to hera_cal\n",
     "def construct_filter(times, fc, fhw, eigval_cutoff=FR_EIGENVAL_CUTOFF, wgts=None):\n",
-    "    \"\"\"Compute the time-domain DPSS filter matrix.\"\"\"\n",
+    "    \"\"\"Compute the time-domain DPSS filter matrix.\n",
+    "\n",
+    "    This function essentially computes a generalization of Eq. 3.17 from Pascua+ 2024\n",
+    "    to allow for non-uniform weighting in time. If the DPSS filter design matrix is A,\n",
+    "    and the weights are W, then the filter matrix T is \n",
+    "    \n",
+    "            T = W @ A @ (A^\\dag @ W @ A)^{-1} @ (W @ A)^\\dag.\n",
+    "\n",
+    "    The design matrix A is Eq. 3.14 from Pascua+ 2024.\n",
+    "    \"\"\"\n",
     "    if wgts is None:\n",
     "        wgts = np.ones(times.size)\n",
     "        \n",
@@ -1206,9 +1216,10 @@
     "    cut = np.argwhere(eigvals >= eigval_cutoff).flatten()[-1]\n",
     "    modes = modes[:cut].T * frf_phasor[:,None]  # Shape (n_times, n_dpss)\n",
     "    \n",
-    "    # Apply the weights, then compute the filter matrix.\n",
-    "    modes = wgts[:,None] * modes\n",
-    "    return modes @ np.linalg.inv(modes.T.conj() @ modes) @ modes.T.conj()"
+    "    # Compute the filter matrix according to a weighted least-squares fit.\n",
+    "    return wgts[:,None] * modes @ np.linalg.inv(\n",
+    "        modes.T.conj() @ (wgts[:,None] * modes)\n",
+    "    ) @ (wgts[:,None] * modes).T.conj()"
    ]
   },
   {
@@ -1258,7 +1269,7 @@
     "    table = pd.DataFrame({'Band': np.arange(len(bands)) + 1,\n",
     "                          'Frequency Range (MHz)': [f'{f0:.1f} — {f1:.1f}' for f0, f1 in zip(min_freqs, max_freqs)],\n",
     "                          f'Main Beam {FR_QUANTILE_LOW:.0%} — {FR_QUANTILE_HIGH:.0%}<br>Kept Fringe Rates (mHz)': [f'{frs[0]:.3f} to {frs[1]:.3f}' for frs in fr_ranges.values()],\n",
-    "                          f'Approximate Signal Loss with<br>{-XTALK_FR} to {XTALK_FR} mHz X-Talk Filter': [f'{loss:.1%}' for loss in frf_losses.values()],\n",
+    "                          f'Signal Loss with<br>{-XTALK_FR} to {XTALK_FR} mHz X-Talk Filter': [f'{loss:.1%}' for loss in frf_losses.values()],\n",
     "                         })\n",
     "    return table.style.hide().to_html()"
    ]
@@ -1270,7 +1281,7 @@
    "source": [
     "# *Table 2: Fringe-Rate and Crosstalk Filtering Ranges and Losses*\n",
     "\n",
-    "Note that these losses are approximate and assume perfectly sharp filters. Extra extent in fringe-rate space (which is controlled by `FR_EIGENVAL_CUTOFF`) will reduce loss when performing the main beam fringe-rate filter (because it is a top hat). It will also will increase the loss due to the crosstalk filtering (because it is a notch) if and only if there's an overlap between the two filters."
+    "The losses computed here are based on an extension of the framework from [Pascua+ 2024](https://arxiv.org/pdf/2410.01872) to allow for non-uniform time weighting. These losses include contributions from both the main beam filter and the crosstalk filter, but do not include losses from coherent time averaging or the time-interleaved incoherent average."
    ]
   },
   {

--- a/notebooks/single_baseline_postprocessing_and_pspec.ipynb
+++ b/notebooks/single_baseline_postprocessing_and_pspec.ipynb
@@ -1234,6 +1234,7 @@
     "# Update frf signal loss calculation.\n",
     "frf_losses = {} \n",
     "for band, band_slice in zip(bands, band_slices):\n",
+    "    # TODO: figure out how to handle frequency and polarization-dependent weights.\n",
     "    # The weights change as a function of frequency (due to the inverse noise weighting),\n",
     "    # so this isn't entirely accurate; will need to update in the future.\n",
     "    # Also need to more carefully consider how to combine the weights across polarization,\n",


### PR DESCRIPTION
This PR adds the signal loss calculation from the [FRF Signal Loss Paper](https://arxiv.org/abs/2410.01872) to the single baseline processing notebook. The calculation implemented here only considers signal loss contributions from the crosstalk and main-lobe filters. I have some concerns about how the calculation I patched together handles the weights&mdash;even though the nsamples used for computing the weights are band-averaged, the sky temperature evolution causes the weights to vary as a function of frequency. For now, I'm just taking the band-averaged weights, but it's worth taking a closer look down the line.

Note that I had to move the FRF summary table to after the inpainting/delay filtering section, since I needed the weights to do the calculation (and those are computed downstream of inpainting/delay filtering). I ran some quick sanity checks, and things look fine. For the example data I tested this out on, the signal loss hovers around 4-6%, and the filter transfer matrix looks about right. If desired, then I can add some plots of what the filter transfer matrices look like, but there's already a lot going on in this notebook. As for compute intensity: it takes about a minute to compute the signal loss for all of the bands.

Another concern I have is that the weights differ between polarizations. For now, I'm just taking the average of the weights over ee/nn and hoping that there aren't issues. I don't think the differing weights will have a major effect, but I'm sure there are nuanced things happening because of it (e.g., the filter applied to ee isn't exactly the same as the filter applied to nn). The signal loss paper took the super simple limit of a uniformly weighted incoherent average for estimating the power spectrum, so I haven't taken a close look at the nuances that come up when the weights have various degrees of variability. (For this PR, I basically just did linear least squares -> generalized linear least squares to extend the formalism from the paper.)

One last thing, I didn't update the text describing the FRF summary table&mdash;I only removed the text saying that in the future it will be updated to the filter transfer-based calculation.

Remaining outstanding TODOs regarding signal loss:
1. Merge this stuff into `hera_cal`
2. Extend the signal loss calculation to include coherent averaging and time interleaving. I have the coherent average calculation sitting around in a notebook somewhere, but the time interleaving is new territory (I'm fairly certain the signal loss formalism can handle it, though).