### PR TITLE
fix: FRF+tavg signal loss calculations

### DIFF
--- a/hera_notebook_templates/notebooks/single_baseline_postprocessing_and_pspec.ipynb
+++ b/hera_notebook_templates/notebooks/single_baseline_postprocessing_and_pspec.ipynb
@@ -1133,6 +1133,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "1e11c073-f722-4603-88c7-d662abe672c7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Compute the band-averaged m-mode spectra.\n",
+    "interp_spec = interpolate.interp1d(spectrum_freqs, mmode_spectrum, kind=\"cubic\", axis=1, fill_value=\"extrapoloate\")(data.freqs)\n",
+    "band_avg_spec = {}\n",
+    "for band, bs in zip(bands, band_slices):\n",
+    "    taper = dspec.gen_window(TAPER, len(data.freqs[bs]))\n",
+    "    band_avg_spec[band] = np.average(interp_spec[:,bs], weights=taper**2, axis=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "ee58a2ac",
    "metadata": {
     "scrolled": true
@@ -1146,12 +1161,19 @@
     "    # Convert m-modes to fringe-rates in mHz.\n",
     "    return m_modes / units.sday.to(units.ks)\n",
     "\n",
+    "# Make one set of mixing matrices for the high resolution times for filter design.\n",
+    "full_times = data.times[tslice]\n",
+    "times_ks = (full_times - full_times[0] + np.median(np.diff(full_times))) * units.day.to(units.ks)\n",
+    "filt_frates = np.fft.fftshift(np.fft.fftfreq(times_ks.size, d=np.median(np.diff(times_ks))))\n",
+    "_m2f_phasors = np.exp(2j * np.pi * m2f(m_modes)[None, :] * times_ks[:, None])\n",
+    "_m2f_mixer = np.fft.fftshift(np.fft.fft(np.fft.ifftshift(_m2f_phasors, axes=0), axis=0), axes=0)\n",
+    "\n",
+    "# Use the deinterleaved time series for signal loss calculation.\n",
     "deint_times = deint_filt_data[0].times\n",
     "times_ks = (deint_times - deint_times[0] + np.median(np.diff(deint_times))) * units.day.to(units.ks)\n",
+    "frates = np.fft.fftshift(np.fft.fftfreq(times_ks.size, d=np.median(np.diff(times_ks))))\n",
     "m2f_phasors = np.exp(2j * np.pi * m2f(m_modes)[None, :] * times_ks[:, None])\n",
-    "m2f_mixer = np.fft.fftshift(np.fft.fft(np.fft.ifftshift(m2f_phasors, axes=0), axis=0), axes=0)\n",
-    "# f is fringe rate, m is m-mode, n is nu (i.e. freqeuency)\n",
-    "fr_spectrum = np.abs(np.einsum('fm,mn,mf->fn', m2f_mixer, mmode_spectrum, m2f_mixer.T.conj()))"
+    "m2f_mixer = np.fft.fftshift(np.fft.fft(np.fft.ifftshift(m2f_phasors, axes=0), axis=0), axes=0)"
    ]
   },
   {
@@ -1162,30 +1184,31 @@
    "outputs": [],
    "source": [
     "# TODO: graduate this code into hera_cal\n",
-    "\n",
-    "# interpolate to all frequencies in data\n",
-    "interp_fr_spectrum = interpolate.interp1d(spectrum_freqs, fr_spectrum, kind='cubic', fill_value='extrapolate')(data.freqs)    \n",
-    "frates = np.fft.fftshift(np.fft.fftfreq(len(times_ks), d=np.median(np.diff(times_ks))))\n",
-    "\n",
     "# perform window-weighted average over each band, then get lower and upper quantiles\n",
     "fr_ranges = {}\n",
     "fr_profiles = {}\n",
     "frf_losses = {}\n",
     "xtalk_overlaps = {}\n",
-    "for band, bs in zip(bands, band_slices):\n",
-    "    taper = dspec.gen_window(TAPER, len(data.freqs[bs]))\n",
-    "    band_avg_fr_spectrum = np.average(interp_fr_spectrum[:, bs], weights=taper**2, axis=1)\n",
+    "for band in bands:\n",
+    "    m_mode_spec = band_avg_spec[band]\n",
+    "\n",
+    "    # Compute the filter bounds.\n",
+    "    band_avg_fr_spectrum = np.abs(np.einsum(\"fm,m,mf->f\", _m2f_mixer, m_mode_spec, _m2f_mixer.T.conj()))\n",
+    "    band_avg_fr_spectrum /= np.sum(band_avg_fr_spectrum)\n",
+    "    cumsum_interpolator = interpolate.interp1d(np.cumsum(band_avg_fr_spectrum), filt_frates)\n",
+    "    fr_ranges[band] = cumsum_interpolator(FR_QUANTILE_LOW), cumsum_interpolator(FR_QUANTILE_HIGH)\n",
+    "\n",
+    "    # Now compute the fringe-rate profile to be used for signal loss calculations.\n",
+    "    band_avg_fr_spectrum = np.abs(np.einsum(\"fm,m,mf->f\", m2f_mixer, m_mode_spec, m2f_mixer.T.conj()))\n",
     "    band_avg_fr_spectrum /= np.sum(band_avg_fr_spectrum)\n",
     "    fr_profiles[band] = band_avg_fr_spectrum\n",
-    "    cumsum_interpolator = interpolate.interp1d(np.cumsum(band_avg_fr_spectrum), frates)\n",
-    "    fr_ranges[band] = cumsum_interpolator(FR_QUANTILE_LOW), cumsum_interpolator(FR_QUANTILE_HIGH)\n",
     "    \n",
     "    # account for overlap between FR=0 notch and main beam FRF\n",
     "    def overlap_frs(frs1, frs2):\n",
     "        start = np.maximum(frs1[0], frs2[0])\n",
     "        end = np.minimum(frs1[1], frs2[1])\n",
     "        return (start, end) if start < end else None\n",
-    "    frate_interpolator = interpolate.interp1d(frates, np.cumsum(band_avg_fr_spectrum))\n",
+    "    frate_interpolator = interpolate.interp1d(frates, np.cumsum(band_avg_fr_spectrum), fill_value=\"extrapolate\")\n",
     "    frf_losses[band] = 1 - frate_interpolator(fr_ranges[band][1]) + frate_interpolator(fr_ranges[band][0])\n",
     "    xtalk_overlaps[band] = overlap_frs(fr_ranges[band], [-XTALK_FR, XTALK_FR])\n",
     "    if xtalk_overlaps[band] is not None:\n",
@@ -1324,7 +1347,7 @@
    "source": [
     "### *Table 2: Fringe-Rate and Crosstalk Filtering Ranges and Losses*\n",
     "\n",
-    "The losses computed here are based on an extension of the framework from [Pascua+ 2024](https://arxiv.org/pdf/2410.01872) to allow for non-uniform time weighting. These losses include contributions from both the main beam filter and the crosstalk filter, but do not include losses from coherent time averaging or the time-interleaved incoherent average."
+    "The losses computed here are based on an extension of the framework from [Pascua+ 2025](https://iopscience.iop.org/article/10.3847/1538-4357/adc37d) to allow for non-uniform time weighting. These losses include contributions from both the main beam filter and the crosstalk filter, but do not include losses from coherent time averaging or the time-interleaved incoherent average."
    ]
   },
   {
@@ -1666,7 +1689,7 @@
     "old_times = deint_filt_data[0].times\n",
     "old_times = (old_times - old_times[0]) * units.day.to(units.s)\n",
     "new_times = np.array(deint_avg_data[0].times)\n",
-    "new_times = (new_times - old_times[0]) * units.day.to(units.s)\n",
+    "new_times = (new_times - deint_filt_data[0].times[0]) * units.day.to(units.s)\n",
     "new_inttime = AVERAGING_TIME"
    ]
   },
@@ -1691,10 +1714,7 @@
     "\n",
     "    # Compute the band-averaged FR profile.\n",
     "    freqs = data.freqs[band_slice]\n",
-    "    avg_spec = np.average(\n",
-    "        interpolate.interp1d(spectrum_freqs, mmode_spectrum, axis=1, kind=\"cubic\", fill_value=\"extrapolate\")(freqs),\n",
-    "        weights=dspec.gen_window(TAPER, freqs.size)**2, axis=1\n",
-    "    )  # Weight by the delay spectrum taper squared.\n",
+    "    avg_spec = band_avg_spec[band]\n",
     "    fr_profile = np.diag(m2f_mixer @ (avg_spec[:,None] * m2f_mixer.T.conj()))\n",
     "    \n",
     "    # Compute the filtered fringe-rate profile and convert to a time-time covariance.\n",
@@ -1753,7 +1773,7 @@
    "source": [
     "# Table 3: Signal Loss Estimates from Fringe-Rate Filters and Coherent Time Average\n",
     "\n",
-    "Similar to Table 2, these losses are computed based on an extension to the framework from [Pascua+ 2024](https://arxiv.org/pdf/2410.01872), using weights that are time-variable (but uniform in frequency). Note that the rightmost column is the **total** loss from the main lobe filter, the crosstalk filter, and the coherent time average."
+    "Similar to Table 2, these losses are computed based on an extension to the framework from [Pascua+ 2025](https://iopscience.iop.org/article/10.3847/1538-4357/adc37d), using weights that are time-variable (but uniform in frequency). Note that the rightmost column is the **total** loss from the main lobe filter, the crosstalk filter, and the coherent time average."
    ]
   },
   {
@@ -2744,7 +2764,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.11.11"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
This PR should fix the errors that cropped up in the signal loss calculations, some of which were detailed in Issue #64. This PR simply skirts the issue by using the original time resolution for computing the fringe-rate filter parameters, and instead using the lower resolution "deinterleaved" times just for the relevant signal loss calculations (in contrast to using the deinterleaved times for all of the calculations as was done prior to this PR). In addition to this, there was a silent bug (which is now fixed) in the coherent time average signal loss calculation where the post-averaging time array was not computed correctly, which led to `nan` signal loss estimates.

Before merging, we ought to consider the fact that some choices of weights can lead to erroneous signal loss estimates. For example, spectral window 11 in `/lustre/aoc/projects/hera/h6c-analysis/IDR2/lstbin-outputs/redavg-smoothcal-inpaint-500ns-lstcal/inpaint/single_baseline_files/zen.LST.baseline.133_155.sum.uvh5` has some issues. The weights array (after averaging over polarization and frequency) looks like this:

![Screenshot from 2025-06-30 15-02-33](https://github.com/user-attachments/assets/7c0f960a-43bb-494d-b393-f2d08282a029)

Apparently the comb in the weights results in fringe-rate filter that looks like this:

![Screenshot from 2025-06-30 15-03-04](https://github.com/user-attachments/assets/036ec7ce-ed3e-4843-ba05-987a455ddfa1)

Consequently, the signal loss calculation for this baseline and spectral window gives something bogus (roughly -4 million percent) relative to the signal loss calculation performed using uniform weights (order a few percent).

One other notable change is that the order of operations for computing the fringe-rate profiles has been shuffled. Prior to this PR, the $m$-mode spectra were converted to fringe-rate profiles, then interpolated to data frequencies, then averaged across the band. In this PR, the order has been changed to first interpolate the $m$-mode spectra to the observed frequencies, perform the band average, then the band-averaged $m$-mode spectra are converted to fringe-rate profiles. This produces no discernible difference in the resulting fringe-rate profiles:

![Screenshot from 2025-06-30 14-16-40](https://github.com/user-attachments/assets/62cb0f67-c30b-4179-9937-fcdde307709b)

This solution is not necessarily the best fix to the problem in Issue #64, but it ought to work for the time being.